### PR TITLE
Fix json.loads(bytes) error

### DIFF
--- a/poyonga/client.py
+++ b/poyonga/client.py
@@ -117,7 +117,7 @@ class Groonga(object):
         if kwargs:
             url = "".join([url, "?", urlencode(kwargs)])
         try:
-            _data = urlopen(url).read()
+            _data = urlopen(url).read().decode(self.encoding)
         except HTTPError as msg:
             _data = msg.read()
         return _data


### PR DESCRIPTION
json.loads can not load `bytes` object which comes from urlopen(url).read().
so I fixed l.120 to decode that bytes output into `str` by given encoding method.
